### PR TITLE
The correct iana name for GB18030 is without the dash

### DIFF
--- a/detector_test.go
+++ b/detector_test.go
@@ -25,7 +25,7 @@ func TestDetector(t *testing.T) {
 		{"8859_1_fr.html", true, "ISO-8859-1", "fr"},
 		{"8859_1_pt.html", true, "ISO-8859-1", "pt"},
 		{"shift_jis.html", true, "Shift_JIS", "ja"},
-		{"gb18030.html", true, "GB-18030", "zh"},
+		{"gb18030.html", true, "GB18030", "zh"},
 		{"euc_jp.html", true, "EUC-JP", "ja"},
 		{"euc_kr.html", true, "EUC-KR", "ko"},
 		{"big5.html", true, "Big5", "zh"},

--- a/example_test.go
+++ b/example_test.go
@@ -23,5 +23,5 @@ func ExampleTextDetector() {
 			result.Language)
 	}
 	// Output:
-	// Detected charset is GB-18030, language is zh
+	// Detected charset is GB18030, language is zh
 }

--- a/multi_byte.go
+++ b/multi_byte.go
@@ -337,7 +337,7 @@ var commonChars_gb_18030 = []uint16{
 
 func newRecognizer_gb_18030() *recognizerMultiByte {
 	return &recognizerMultiByte{
-		"GB-18030",
+		"GB18030",
 		"zh",
 		charDecoder_gb_18030{},
 		commonChars_gb_18030,


### PR DESCRIPTION
See http://www.iana.org/assignments/charset-reg/GB18030
